### PR TITLE
CF-001: make Enter default to Yes for confirm prompts

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -62,7 +62,8 @@
     "autoincrement",
     "biome",
     "biomejs",
-    "currfix"
+    "currfix",
+    "unstub"
   ],
   "ignorePaths": [
     ".vscode/",

--- a/src/prompts/cicd.js
+++ b/src/prompts/cicd.js
@@ -21,7 +21,7 @@ export async function askCicdQuestions(projectType) {
         type: 'confirm',
         name: 'setupCicd',
         message: 'Set up CI/CD pipeline?',
-        default: false,
+        default: true,
       },
     ]);
     setupCicd = result.setupCicd;

--- a/src/prompts/cli.js
+++ b/src/prompts/cli.js
@@ -48,7 +48,7 @@ export async function askCliQuestions() {
         type: 'confirm',
         name: 'setupSemanticRelease',
         message: 'Set up semantic-release for automated npm publishing?',
-        default: false,
+        default: true,
       },
     ]);
     setupSemanticRelease = result.setupSemanticRelease;

--- a/src/prompts/database.js
+++ b/src/prompts/database.js
@@ -20,7 +20,7 @@ export async function askDatabaseQuestions() {
         type: 'confirm',
         name: 'setupDatabase',
         message: 'Set up a database?',
-        default: false,
+        default: true,
       },
     ]);
     setupDatabase = result.setupDatabase;
@@ -75,7 +75,7 @@ export async function askDatabaseQuestions() {
         type: 'confirm',
         name: 'setupRedis',
         message: 'Set up Redis for caching?',
-        default: false,
+        default: true,
       },
     ]);
     setupRedis = result.setupRedis;

--- a/src/prompts/playwright.js
+++ b/src/prompts/playwright.js
@@ -24,7 +24,7 @@ export async function askPlaywrightQuestion(projectType) {
       type: 'confirm',
       name: 'setupPlaywright',
       message: 'Set up Playwright for E2E testing?',
-      default: false,
+      default: true,
     },
   ]);
 

--- a/tests/integration/prompts-defaults.int.test.js
+++ b/tests/integration/prompts-defaults.int.test.js
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { prompt } from '../../src/utils/prompt.js';
+import { askCicdQuestions } from '../../src/prompts/cicd.js';
+import { askCliQuestions } from '../../src/prompts/cli.js';
+import { askDatabaseQuestions } from '../../src/prompts/database.js';
+import { askPlaywrightQuestion } from '../../src/prompts/playwright.js';
+
+vi.mock('../../src/utils/prompt.js', () => ({
+  prompt: vi.fn(),
+}));
+
+const originalIsTTY = process.stdin.isTTY;
+
+describe('confirm prompt defaults', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+  });
+
+  it('uses default=true for database and redis confirms', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    vi.stubEnv('SETUP_DATABASE', '');
+    vi.stubEnv('SETUP_REDIS', '');
+    vi.stubEnv('DB_ENGINE', 'postgresql');
+    vi.stubEnv('DB_ORM', 'none');
+
+    prompt.mockResolvedValueOnce({ setupDatabase: true }).mockResolvedValueOnce({ setupRedis: true });
+
+    await askDatabaseQuestions();
+
+    expect(prompt).toHaveBeenNthCalledWith(
+      1,
+      expect.arrayContaining([expect.objectContaining({ type: 'confirm', name: 'setupDatabase', default: true })]),
+    );
+    expect(prompt).toHaveBeenNthCalledWith(
+      2,
+      expect.arrayContaining([expect.objectContaining({ type: 'confirm', name: 'setupRedis', default: true })]),
+    );
+  });
+
+  it('uses default=true for ci/cd confirm', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    vi.stubEnv('SETUP_CICD', '');
+
+    prompt.mockResolvedValueOnce({ setupCicd: false });
+
+    await askCicdQuestions('backend');
+
+    expect(prompt).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ type: 'confirm', name: 'setupCicd', default: true })]),
+    );
+  });
+
+  it('uses default=true for playwright confirm', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    vi.unstubAllEnvs();
+
+    prompt.mockResolvedValueOnce({ setupPlaywright: true });
+
+    await askPlaywrightQuestion('frontend');
+
+    expect(prompt).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ type: 'confirm', name: 'setupPlaywright', default: true })]),
+    );
+  });
+
+  it('uses default=true for CLI semantic-release confirm', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    vi.stubEnv('CLI_FRAMEWORK', 'commander');
+    vi.stubEnv('CLI_NAME', 'demo-cli');
+    vi.stubEnv('SEMANTIC_RELEASE', '');
+
+    prompt.mockResolvedValueOnce({ setupSemanticRelease: true });
+
+    await askCliQuestions();
+
+    expect(prompt).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'confirm', name: 'setupSemanticRelease', default: true }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- set all wizard confirm prompts to default to `true` so pressing Enter consistently selects Yes
- added integration coverage asserting confirm defaults for database, Redis, CI/CD, Playwright, and CLI semantic-release prompts
- verified with: `npm run test -- tests/integration/prompts-defaults.int.test.js`