### PR TITLE
CF-002: use node:path in generated Vitest configs

### DIFF
--- a/src/templates/common/vitest.config.coverage.ts
+++ b/src/templates/common/vitest.config.coverage.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 
 import { defineConfig } from 'vitest/config';
 

--- a/src/templates/common/vitest.config.native.ts
+++ b/src/templates/common/vitest.config.native.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 
 import { defineConfig } from 'vitest/config';
 

--- a/tests/integration/index.int.test.js
+++ b/tests/integration/index.int.test.js
@@ -151,6 +151,14 @@ describe('tskickstart CLI', () => {
     expect(content).toContain("'@'");
   });
 
+  it('native vitest.config.ts uses node: import protocol for path', () => {
+    tmpDir = createTmpProject();
+    runCli(tmpDir, { VITEST_PRESET: 'native' });
+    const content = readFileSync(join(tmpDir, 'vitest.config.ts'), 'utf-8');
+    expect(content).toContain("from 'node:path'");
+    expect(content).not.toContain("from 'path'");
+  });
+
   it('native vitest.config.ts includes both test and tests directories', () => {
     tmpDir = createTmpProject();
     runCli(tmpDir, { VITEST_PRESET: 'native' });
@@ -191,6 +199,14 @@ describe('tskickstart CLI', () => {
     expect(content).toContain('coverage');
     expect(content).toContain('json-summary');
     expect(content).toContain('reportOnFailure');
+  });
+
+  it('coverage vitest.config.ts uses node: import protocol for path', () => {
+    tmpDir = createTmpProject();
+    runCli(tmpDir, { VITEST_PRESET: 'coverage' });
+    const content = readFileSync(join(tmpDir, 'vitest.config.ts'), 'utf-8');
+    expect(content).toContain("from 'node:path'");
+    expect(content).not.toContain("from 'path'");
   });
 
   it('injects test, test:unit, test:integration, test:coverage scripts for coverage preset', () => {


### PR DESCRIPTION
## Summary
- updated native and coverage Vitest config templates to import `resolve` from `node:path`
- added integration assertions to ensure generated `vitest.config.ts` files use `node:` protocol imports
- verified with: `npm run test -- tests/integration/index.int.test.js`