### PR TITLE
CF-003: align ESLint/Biome on node: import convention

### DIFF
--- a/src/templates/common/biome.json
+++ b/src/templates/common/biome.json
@@ -8,7 +8,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "style": {
+        "useNodejsImportProtocol": "error"
+      }
     }
   },
   "javascript": {

--- a/src/templates/common/eslint.config.js
+++ b/src/templates/common/eslint.config.js
@@ -49,6 +49,7 @@ export default tseslint.config(
       'import/no-self-import': 'error',
       'import/no-unresolved': 'error',
       'import/no-useless-path-segments': 'error',
+      'import/enforce-node-protocol-usage': ['error', 'always'],
       'import/order': [
         'error',
         {

--- a/src/templates/common/eslintCspell.config.js
+++ b/src/templates/common/eslintCspell.config.js
@@ -50,6 +50,7 @@ export default tseslint.config(
       'import/no-self-import': 'error',
       'import/no-unresolved': 'error',
       'import/no-useless-path-segments': 'error',
+      'import/enforce-node-protocol-usage': ['error', 'always'],
       'import/order': [
         'error',
         {

--- a/src/templates/common/vitest.config.coverage.ts
+++ b/src/templates/common/vitest.config.coverage.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 
 import { defineConfig } from 'vitest/config';
 

--- a/src/templates/common/vitest.config.native.ts
+++ b/src/templates/common/vitest.config.native.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 
 import { defineConfig } from 'vitest/config';
 

--- a/tests/integration/biome.int.test.js
+++ b/tests/integration/biome.int.test.js
@@ -50,6 +50,14 @@ describe('biome option', () => {
     expect(pkg['lint-staged']['**/*']).toContain('biome check --write .');
   });
 
+  it('enforces node: protocol in biome config', () => {
+    tmpDir = createTmpProject();
+    runCli(tmpDir, { LINTER: 'biome' });
+
+    const content = readFileSync(join(tmpDir, 'biome.json'), 'utf-8');
+    expect(content).toContain('useNodejsImportProtocol');
+  });
+
   it('keeps cspell standalone when biome is selected', () => {
     tmpDir = createTmpProject();
     runCli(tmpDir, { LINTER: 'biome', LINT_OPTIONS: 'cspell' });

--- a/tests/integration/index.int.test.js
+++ b/tests/integration/index.int.test.js
@@ -38,6 +38,14 @@ describe('tskickstart CLI', () => {
     expect(existsSync(join(tmpDir, 'eslint.config.js'))).toBe(true);
   });
 
+  it('eslint config enforces node: protocol for built-in imports', () => {
+    tmpDir = createTmpProject();
+    runCli(tmpDir);
+    const content = readFileSync(join(tmpDir, 'eslint.config.js'), 'utf-8');
+    expect(content).toContain('import/enforce-node-protocol-usage');
+    expect(content).toContain("'always'");
+  });
+
   it('copies prettier.config.js to the target directory', () => {
     tmpDir = createTmpProject();
     runCli(tmpDir);
@@ -151,6 +159,14 @@ describe('tskickstart CLI', () => {
     expect(content).toContain("'@'");
   });
 
+  it('native vitest.config.ts uses node: import protocol for path', () => {
+    tmpDir = createTmpProject();
+    runCli(tmpDir, { VITEST_PRESET: 'native' });
+    const content = readFileSync(join(tmpDir, 'vitest.config.ts'), 'utf-8');
+    expect(content).toContain("from 'node:path'");
+    expect(content).not.toContain("from 'path'");
+  });
+
   it('native vitest.config.ts includes both test and tests directories', () => {
     tmpDir = createTmpProject();
     runCli(tmpDir, { VITEST_PRESET: 'native' });
@@ -191,6 +207,14 @@ describe('tskickstart CLI', () => {
     expect(content).toContain('coverage');
     expect(content).toContain('json-summary');
     expect(content).toContain('reportOnFailure');
+  });
+
+  it('coverage vitest.config.ts uses node: import protocol for path', () => {
+    tmpDir = createTmpProject();
+    runCli(tmpDir, { VITEST_PRESET: 'coverage' });
+    const content = readFileSync(join(tmpDir, 'vitest.config.ts'), 'utf-8');
+    expect(content).toContain("from 'node:path'");
+    expect(content).not.toContain("from 'path'");
   });
 
   it('injects test, test:unit, test:integration, test:coverage scripts for coverage preset', () => {


### PR DESCRIPTION
## Summary
- enforced `node:` protocol in generated ESLint configs via `import/enforce-node-protocol-usage`
- explicitly enabled Biome `useNodejsImportProtocol` and aligned Vitest templates to `node:path`
- added integration tests for ESLint/Biome enforcement and generated Vitest config imports

## Verification
- npm run test -- tests/integration/index.int.test.js tests/integration/biome.int.test.js