### PR TITLE
CF-016: align backend README with docker-compose behavior

### DIFF
--- a/src/utils/readme.js
+++ b/src/utils/readme.js
@@ -338,7 +338,7 @@ tests/
     lines.push('    server.unit.test.ts  # Unit tests for route handlers');
     if (setupDocker) {
       lines.push('Dockerfile         # Multi-stage production build');
-      lines.push('docker-compose.yml # Local development with hot-reload mount');
+      lines.push('docker-compose.yml # Container orchestration for app + optional DB services');
       lines.push('Makefile           # Docker convenience targets: make docker-up, make docker-down');
     }
     lines.push('```');

--- a/tests/integration/readme.int.test.js
+++ b/tests/integration/readme.int.test.js
@@ -205,6 +205,7 @@ describe('deep project structure', () => {
     const structure = content.split('## Project Structure')[1];
     expect(structure).toContain('Dockerfile');
     expect(structure).toContain('docker-compose');
+    expect(structure).not.toContain('hot-reload mount');
   });
 
   it('backend structure omits Docker files when Docker disabled', () => {


### PR DESCRIPTION
## Summary
- updated backend project-structure docs to describe docker-compose as service orchestration, not hot-reload volume mounting
- added regression assertion in README integration tests to prevent reintroducing the hot-reload mount claim

## Verification
- npm run test -- tests/integration/readme.int.test.js