### PR TITLE
CF-013: make Scripts Reference linter-aware

### DIFF
--- a/src/utils/readme.js
+++ b/src/utils/readme.js
@@ -1242,14 +1242,15 @@ function getScriptsTable(answers) {
     setupAppDetox,
     setupDocker,
     lintOption = [],
+    linter = 'eslint',
   } = answers;
   const rows = [];
 
   rows.push('| Script | Description |');
   rows.push('| --- | --- |');
   rows.push('| `npm run check` | Run all quality checks |');
-  rows.push('| `npm run format` | Format code with Prettier |');
-  rows.push('| `npm run lint` | Lint with ESLint |');
+  rows.push(`| \`npm run format\` | Format code with ${linter === 'biome' ? 'Biome' : 'Prettier'} |`);
+  rows.push(`| \`npm run lint\` | Lint with ${linter === 'biome' ? 'Biome' : 'ESLint'} |`);
   rows.push('| `npm run typecheck` | Type-check with TypeScript |');
 
   if (lintOption.includes('cspell')) rows.push('| `npm run spellcheck` | Check spelling |');

--- a/tests/integration/readme.int.test.js
+++ b/tests/integration/readme.int.test.js
@@ -453,6 +453,24 @@ describe('section ordering and overall structure', () => {
   });
 });
 
+describe('scripts reference is linter-aware', () => {
+  it('uses Biome wording when biome is selected', () => {
+    const content = generateReadme(backendAnswers({ linter: 'biome' }));
+    const scripts = content.split('## Scripts Reference')[1];
+    expect(scripts).toContain('Format code with Biome');
+    expect(scripts).toContain('Lint with Biome');
+    expect(scripts).not.toContain('Prettier');
+    expect(scripts).not.toContain('ESLint');
+  });
+
+  it('uses ESLint + Prettier wording when eslint is selected', () => {
+    const content = generateReadme(backendAnswers({ linter: 'eslint' }));
+    const scripts = content.split('## Scripts Reference')[1];
+    expect(scripts).toContain('Format code with Prettier');
+    expect(scripts).toContain('Lint with ESLint');
+  });
+});
+
 // ---------------------------------------------------------------------------
 // 8. All backend framework variants produce valid README
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- updated README Scripts Reference generation to describe `format`/`lint` based on selected linter (Biome vs ESLint+Prettier)
- added integration tests to lock linter-aware wording for both biome and eslint modes

## Verification
- npm run test -- tests/integration/readme.int.test.js