### PR TITLE
CF-014: wire DATABASE_URL into generated env validation

### DIFF
--- a/src/generators/database.js
+++ b/src/generators/database.js
@@ -291,6 +291,31 @@ async function upsertEnvExample(cwd, url) {
   await fs.writeFile(envPath, `${lines.join('\n')}\n`);
 }
 
+async function patchBackendEnvForDatabase(cwd) {
+  const envPath = path.join(cwd, 'src/env.ts');
+  if (!(await fs.pathExists(envPath))) return;
+
+  const content = await fs.readFile(envPath, 'utf-8');
+  if (content.includes('DATABASE_URL')) return;
+
+  if (content.includes('const envSchema = z.object({')) {
+    const next = content.replace(
+      'const envSchema = z.object({',
+      'const envSchema = z.object({\n  DATABASE_URL: z.string().min(1),',
+    );
+    await fs.writeFile(envPath, next);
+    return;
+  }
+
+  if (content.includes('export const env = {')) {
+    const next = content.replace(
+      'export const env = {',
+      "export const env = {\n  DATABASE_URL: process.env.DATABASE_URL ?? '',",
+    );
+    await fs.writeFile(envPath, next);
+  }
+}
+
 async function appendReadmeSection(cwd, engine, orm) {
   const readmePath = path.join(cwd, 'README.md');
   if (!(await fs.pathExists(readmePath))) return;
@@ -379,6 +404,7 @@ export const Example = model('Example', exampleSchema);
   }
 
   await upsertEnvExample(cwd, meta.url);
+  await patchBackendEnvForDatabase(cwd);
   await appendReadmeSection(cwd, engine, orm);
 
   if (answers.setupDocker) {

--- a/tests/integration/database.int.test.js
+++ b/tests/integration/database.int.test.js
@@ -106,6 +106,36 @@ describe('database scaffold', () => {
     expect(envExample).toContain('mysql://');
   });
 
+  it('wires DATABASE_URL into src/env.ts validation when zod is enabled', () => {
+    tmpDir = createTmpProject();
+    runCli(tmpDir, {
+      SETUP_DATABASE: '1',
+      DB_ENGINE: 'postgresql',
+      DB_ORM: 'drizzle',
+      DOCKER: '0',
+      BACKEND_ZOD: '1',
+    });
+
+    const envFile = readFileSync(join(tmpDir, 'src/env.ts'), 'utf-8');
+    expect(envFile).toContain('DATABASE_URL');
+    expect(envFile).toContain('z.string().min(1)');
+  });
+
+  it('wires DATABASE_URL into src/env.ts when zod is disabled', () => {
+    tmpDir = createTmpProject();
+    runCli(tmpDir, {
+      SETUP_DATABASE: '1',
+      DB_ENGINE: 'postgresql',
+      DB_ORM: 'drizzle',
+      DOCKER: '0',
+      BACKEND_ZOD: '0',
+    });
+
+    const envFile = readFileSync(join(tmpDir, 'src/env.ts'), 'utf-8');
+    expect(envFile).toContain('DATABASE_URL');
+    expect(envFile).toContain('process.env.DATABASE_URL');
+  });
+
   it('adds a README database section', () => {
     tmpDir = createTmpProject();
     runCli(tmpDir, {


### PR DESCRIPTION
## Summary
- added database-aware env patching so backend `src/env.ts` includes `DATABASE_URL` when database setup is selected
- supports both zod and non-zod env templates while keeping generation idempotent
- added integration tests for both env validation modes

## Verification
- npm run test -- tests/integration/database.int.test.js