### PR TITLE
CF-007: add engine/ORM-aware DB scripts

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -63,7 +63,9 @@
     "biome",
     "biomejs",
     "currfix",
-    "unstub"
+    "unstub",
+    "psql",
+    "mongosh"
   ],
   "ignorePaths": [
     ".vscode/",

--- a/src/utils/scripts.js
+++ b/src/utils/scripts.js
@@ -156,6 +156,33 @@ export function buildScripts(pkg, answers) {
       pkg.scripts['docker:build'] =
         'sh -c \'if docker compose version >/dev/null 2>&1; then docker compose build; elif command -v docker-compose >/dev/null 2>&1; then docker-compose build; else echo "Docker Compose is not installed" >&2; exit 1; fi\'';
     }
+
+    if (answers.setupDatabase) {
+      const engine = answers.databaseEngine ?? 'postgresql';
+      const orm = answers.databaseOrm ?? (engine === 'mongodb' ? 'mongoose' : 'none');
+
+      if (orm === 'drizzle') {
+        pkg.scripts['db:generate'] = 'drizzle-kit generate';
+        pkg.scripts['db:migrate'] = 'drizzle-kit migrate';
+        pkg.scripts['db:studio'] = 'drizzle-kit studio';
+      } else if (orm === 'prisma') {
+        pkg.scripts['db:generate'] = 'prisma generate';
+        pkg.scripts['db:migrate'] = 'prisma migrate dev';
+        pkg.scripts['db:studio'] = 'prisma studio';
+      } else if (orm === 'none') {
+        pkg.scripts['db:migrate'] = 'node --import tsx src/db/migrate.ts';
+      }
+
+      if (engine === 'postgresql') {
+        pkg.scripts['db:shell'] = 'psql "$DATABASE_URL"';
+      } else if (engine === 'mysql' || engine === 'mariadb') {
+        pkg.scripts['db:shell'] = 'mysql "$DATABASE_URL"';
+      } else if (engine === 'sqlite') {
+        pkg.scripts['db:shell'] = 'sqlite3 dev.db';
+      } else if (engine === 'mongodb') {
+        pkg.scripts['db:shell'] = 'mongosh "$DATABASE_URL"';
+      }
+    }
   }
 
   if (projectType === 'app') {

--- a/tests/integration/database.int.test.js
+++ b/tests/integration/database.int.test.js
@@ -169,6 +169,54 @@ describe('database scaffold', () => {
     expect(migrate).toContain('readFile');
   });
 
+  it('adds engine and ORM aware DB scripts for drizzle + postgresql', () => {
+    tmpDir = createTmpProject();
+    runCli(tmpDir, {
+      SETUP_DATABASE: '1',
+      DB_ENGINE: 'postgresql',
+      DB_ORM: 'drizzle',
+      DOCKER: '0',
+    });
+
+    const pkg = JSON.parse(readFileSync(join(tmpDir, 'package.json'), 'utf-8'));
+    expect(pkg.scripts).toHaveProperty('db:generate');
+    expect(pkg.scripts).toHaveProperty('db:migrate');
+    expect(pkg.scripts).toHaveProperty('db:studio');
+    expect(pkg.scripts).toHaveProperty('db:shell');
+    expect(pkg.scripts['db:migrate']).toContain('drizzle-kit');
+    expect(pkg.scripts['db:shell']).toContain('psql');
+  });
+
+  it('adds engine and ORM aware DB scripts for prisma + mysql', () => {
+    tmpDir = createTmpProject();
+    runCli(tmpDir, {
+      SETUP_DATABASE: '1',
+      DB_ENGINE: 'mysql',
+      DB_ORM: 'prisma',
+      DOCKER: '0',
+    });
+
+    const pkg = JSON.parse(readFileSync(join(tmpDir, 'package.json'), 'utf-8'));
+    expect(pkg.scripts['db:generate']).toContain('prisma generate');
+    expect(pkg.scripts['db:migrate']).toContain('prisma migrate dev');
+    expect(pkg.scripts['db:studio']).toContain('prisma studio');
+    expect(pkg.scripts['db:shell']).toContain('mysql');
+  });
+
+  it('adds raw migration scripts for none ORM + sqlite', () => {
+    tmpDir = createTmpProject();
+    runCli(tmpDir, {
+      SETUP_DATABASE: '1',
+      DB_ENGINE: 'sqlite',
+      DB_ORM: 'none',
+      DOCKER: '0',
+    });
+
+    const pkg = JSON.parse(readFileSync(join(tmpDir, 'package.json'), 'utf-8'));
+    expect(pkg.scripts['db:migrate']).toContain('src/db/migrate.ts');
+    expect(pkg.scripts['db:shell']).toContain('sqlite3');
+  });
+
   it('generates redis starter files, env, docker service and docs when redis is enabled', () => {
     tmpDir = createTmpProject();
     runCli(tmpDir, {


### PR DESCRIPTION
## Summary
- added backend package scripts for DB workflows by engine+ORM (`db:generate`, `db:migrate`, `db:studio`, `db:shell`)
- covers Drizzle, Prisma, and raw migration flows with engine-specific shell commands
- added integration tests for drizzle+postgres, prisma+mysql, and raw+sqlite script generation

## Verification
- npm run test -- tests/integration/database.int.test.js