### PR TITLE
CF-005: add DB-focused Docker and Make daily workflows

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -63,7 +63,9 @@
     "biome",
     "biomejs",
     "currfix",
-    "unstub"
+    "unstub",
+    "psql",
+    "mongosh"
   ],
   "ignorePaths": [
     ".vscode/",

--- a/src/templates/backend/Makefile
+++ b/src/templates/backend/Makefile
@@ -1,6 +1,6 @@
 COMPOSE := $(shell if command -v docker-compose >/dev/null 2>&1; then echo docker-compose; elif docker compose version >/dev/null 2>&1; then echo "docker compose"; else echo docker-compose; fi)
 
-.PHONY: docker-up docker-down docker-logs docker-build
+.PHONY: docker-up docker-down docker-logs docker-build docker-db-up docker-db-down docker-db-logs docker-db-shell docker-db-migrate
 
 docker-up: ; $(COMPOSE) up --build
 
@@ -9,3 +9,13 @@ docker-down: ; $(COMPOSE) down
 docker-logs: ; $(COMPOSE) logs -f
 
 docker-build: ; $(COMPOSE) build
+
+docker-db-up: ; $(COMPOSE) up -d db
+
+docker-db-down: ; $(COMPOSE) stop db
+
+docker-db-logs: ; $(COMPOSE) logs -f db
+
+docker-db-shell: ; $(COMPOSE) exec db sh
+
+docker-db-migrate: ; npm run db:migrate

--- a/src/utils/scripts.js
+++ b/src/utils/scripts.js
@@ -155,6 +155,29 @@ export function buildScripts(pkg, answers) {
         'sh -c \'if docker compose version >/dev/null 2>&1; then docker compose logs -f; elif command -v docker-compose >/dev/null 2>&1; then docker-compose logs -f; else echo "Docker Compose is not installed" >&2; exit 1; fi\'';
       pkg.scripts['docker:build'] =
         'sh -c \'if docker compose version >/dev/null 2>&1; then docker compose build; elif command -v docker-compose >/dev/null 2>&1; then docker-compose build; else echo "Docker Compose is not installed" >&2; exit 1; fi\'';
+
+      if (answers.setupDatabase) {
+        const engine = answers.databaseEngine ?? 'postgresql';
+        const dbShellCmd =
+          engine === 'postgresql'
+            ? 'psql "$DATABASE_URL"'
+            : engine === 'mysql' || engine === 'mariadb'
+              ? 'mysql "$DATABASE_URL"'
+              : engine === 'sqlite'
+                ? 'sqlite3 dev.db'
+                : 'mongosh "$DATABASE_URL"';
+
+        pkg.scripts['docker:db:up'] =
+          'sh -c \'if docker compose version >/dev/null 2>&1; then docker compose up -d db; elif command -v docker-compose >/dev/null 2>&1; then docker-compose up -d db; else echo "Docker Compose is not installed" >&2; exit 1; fi\'';
+        pkg.scripts['docker:db:down'] =
+          'sh -c \'if docker compose version >/dev/null 2>&1; then docker compose stop db; elif command -v docker-compose >/dev/null 2>&1; then docker-compose stop db; else echo "Docker Compose is not installed" >&2; exit 1; fi\'';
+        pkg.scripts['docker:db:logs'] =
+          'sh -c \'if docker compose version >/dev/null 2>&1; then docker compose logs -f db; elif command -v docker-compose >/dev/null 2>&1; then docker-compose logs -f db; else echo "Docker Compose is not installed" >&2; exit 1; fi\'';
+        pkg.scripts['docker:db:shell'] =
+          `sh -c 'if docker compose version >/dev/null 2>&1; then docker compose exec db sh -lc "${dbShellCmd}"; elif command -v docker-compose >/dev/null 2>&1; then docker-compose exec db sh -lc "${dbShellCmd}"; else echo "Docker Compose is not installed" >&2; exit 1; fi'`;
+        pkg.scripts['docker:db:migrate'] =
+          'sh -c \'if [ -n "$(npm run | grep -E " db:migrate")" ]; then npm run db:migrate; else echo "No db:migrate script defined for current ORM/engine"; fi\'';
+      }
     }
   }
 

--- a/tests/integration/backend.int.test.js
+++ b/tests/integration/backend.int.test.js
@@ -169,6 +169,8 @@ describe('backend project scaffold', () => {
     const content = readFileSync(join(tmpDir, 'Makefile'), 'utf-8');
     expect(content).toContain('docker-up: ; $(COMPOSE) up --build');
     expect(content).toContain('docker-down: ; $(COMPOSE) down');
+    expect(content).toContain('docker-db-up: ; $(COMPOSE) up -d db');
+    expect(content).toContain('docker-db-logs: ; $(COMPOSE) logs -f db');
   });
 
   it('creates .dockerignore when DOCKER=1', () => {

--- a/tests/integration/database.int.test.js
+++ b/tests/integration/database.int.test.js
@@ -92,6 +92,23 @@ describe('database scaffold', () => {
     expect(compose).toContain('postgres');
   });
 
+  it('adds db-focused docker scripts when database + docker are enabled', () => {
+    tmpDir = createTmpProject();
+    runCli(tmpDir, {
+      SETUP_DATABASE: '1',
+      DB_ENGINE: 'postgresql',
+      DB_ORM: 'drizzle',
+      DOCKER: '1',
+    });
+
+    const pkg = JSON.parse(readFileSync(join(tmpDir, 'package.json'), 'utf-8'));
+    expect(pkg.scripts).toHaveProperty('docker:db:up');
+    expect(pkg.scripts).toHaveProperty('docker:db:down');
+    expect(pkg.scripts).toHaveProperty('docker:db:logs');
+    expect(pkg.scripts).toHaveProperty('docker:db:shell');
+    expect(pkg.scripts).toHaveProperty('docker:db:migrate');
+  });
+
   it('writes a connection string template in .env.example', () => {
     tmpDir = createTmpProject();
     runCli(tmpDir, {


### PR DESCRIPTION
## Summary
- added db-focused docker scripts (`docker:db:up/down/logs/shell/migrate`) when Docker + database are enabled
- extended backend Makefile with db-only targets for up/down/logs/shell/migrate
- added integration coverage for generated scripts and Makefile db targets

## Verification
- npm run test -- tests/integration/backend.int.test.js tests/integration/database.int.test.js