### PR TITLE
CF-017: add DB connectivity integration test starter

### DIFF
--- a/src/generators/database.js
+++ b/src/generators/database.js
@@ -248,6 +248,51 @@ export default defineConfig({
 `;
 }
 
+function renderDbConnectivityTest(engine, orm) {
+  const importLine =
+    orm === 'mongoose' ? "import { connectDb } from '../../src/db';" : "import { db } from '../../src/db';";
+
+  let connectivityBody = '';
+  if (orm === 'mongoose') {
+    connectivityBody = `
+    await connectDb();
+    expect(true).toBe(true);
+`;
+  } else if (orm === 'prisma') {
+    connectivityBody = `
+    // Generic health check query through Prisma
+    const result = await db.$queryRaw\`SELECT 1 as ok\`;
+    expect(result).toBeDefined();
+`;
+  } else if (engine === 'sqlite') {
+    connectivityBody = `
+    const result = db.prepare('SELECT 1 as ok').get();
+    expect(result.ok).toBe(1);
+`;
+  } else {
+    connectivityBody = `
+    const result = await db.query('SELECT 1 as ok');
+    const row = Array.isArray(result?.rows) ? result.rows[0] : result?.[0]?.[0] ?? result?.[0];
+    expect(row).toBeDefined();
+`;
+  }
+
+  return `import { describe, expect, it } from 'vitest';
+
+${importLine}
+
+describe('database connectivity', () => {
+  it('executes a basic query path when DATABASE_URL is configured', async () => {
+    if (!process.env.DATABASE_URL && '${engine}' !== 'sqlite') {
+      // Starter guard: provide env then remove this guard for strict CI usage.
+      return;
+    }
+${connectivityBody}
+  });
+});
+`;
+}
+
 function renderPrismaSchema(engine) {
   const provider = engineMeta[engine].prismaProvider;
   return `generator client {
@@ -465,6 +510,8 @@ export async function generateDatabase(answers, cwd) {
 
   const dbDir = path.join(cwd, 'src/db');
   await fs.ensureDir(dbDir);
+  const testDir = path.join(cwd, 'tests/integration');
+  await fs.ensureDir(testDir);
 
   if (orm === 'none') {
     await fs.writeFile(path.join(dbDir, 'index.ts'), renderRawIndex(engine));
@@ -517,6 +564,8 @@ export const Example = model('Example', exampleSchema);
 `,
     );
   }
+
+  await fs.writeFile(path.join(testDir, 'db-connectivity.int.test.ts'), renderDbConnectivityTest(engine, orm));
 
   await upsertEnvExample(cwd, meta.url);
   await patchBackendEnvForDatabase(cwd);

--- a/tests/integration/database.int.test.js
+++ b/tests/integration/database.int.test.js
@@ -186,6 +186,24 @@ describe('database scaffold', () => {
     expect(migrate).toContain('readFile');
   });
 
+  it('creates a DB connectivity integration test starter', () => {
+    tmpDir = createTmpProject();
+    runCli(tmpDir, {
+      SETUP_DATABASE: '1',
+      DB_ENGINE: 'postgresql',
+      DB_ORM: 'drizzle',
+      DOCKER: '0',
+      VITEST_PRESET: 'native',
+    });
+
+    const testFile = join(tmpDir, 'tests/integration/db-connectivity.int.test.ts');
+    expect(existsSync(testFile)).toBe(true);
+    const content = readFileSync(testFile, 'utf-8');
+    expect(content).toContain('database connectivity');
+    expect(content).toContain('DATABASE_URL');
+    expect(content).toContain('SELECT 1');
+  });
+
   it('adds engine and ORM aware DB scripts for drizzle + postgresql', () => {
     tmpDir = createTmpProject();
     runCli(tmpDir, {


### PR DESCRIPTION
## Summary
- now generates `tests/integration/db-connectivity.int.test.ts` whenever database setup is enabled
- starter test includes a basic `SELECT 1` query path (or mongoose connect path) with a pragmatic env guard for local bootstrapping
- added integration test coverage asserting the connectivity starter file is generated with expected baseline content

## Verification
- npm run test -- tests/integration/database.int.test.js