### PR TITLE
CF-008: codify DB as backend-only capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ The CLI first asks what you're building, then tailors everything to that choice:
 | **backend service** | Hono/Fastify/Express/Elysia templates + optional Docker + tests |
 | **frontend app**    | React + Vite + Tailwind CSS v4 starter with component tests     |
 | **mobile app**      | React Native + Expo starter with optional Jest and Detox        |
-| **fullstack app**   | Shared baseline now, dedicated fullstack templates planned      |
 
 All project types share a common foundation: ESLint 9 flat config, Prettier, TypeScript strict mode, and optional tooling (Vitest, Husky, CSpell, Secretlint, Commitlint).
 
@@ -53,6 +52,8 @@ All project types share a common foundation: ESLint 9 flat config, Prettier, Typ
 - **Docker:** optional `Dockerfile` + `docker-compose.yml` + `Makefile` with lifecycle-safe setup
 - **Tests:** framework-specific test templates included
 
+> Database scaffolding is intentionally a **backend capability**. Non-backend project types do not prompt for database setup.
+
 ### Frontend app
 
 - **Stack:** React 18 + Vite + Tailwind CSS v4 (Vite plugin)
@@ -77,7 +78,7 @@ All project types share a common foundation: ESLint 9 flat config, Prettier, Typ
 
 Running `npm create @jeportie/tskickstart` inside a project directory will:
 
-1. **Ask your project type** — npm library, CLI tool, backend, frontend, mobile, or fullstack
+1. **Ask your project type** — npm library, CLI tool, backend, frontend, or mobile
 2. **Ensure `package.json` exists** — creates one with `npm init -y` if missing, or patches `"type": "module"`
 3. **Install** all required dev dependencies for your selections
 4. **Copy** config files and starter templates into your project root
@@ -95,7 +96,7 @@ Running `npm create @jeportie/tskickstart` inside a project directory will:
 | **Select more lint options** | Multi-select: `cspell`, `secretlint`, `commitlint` |
 | **Set up Vitest?** | Optional test runner — choose Native or Coverage preset |
 | **Set up pre-commit hook?** | Husky + lint-staged wired to your selected tools |
-| **Set up Playwright?** | E2E testing with Playwright (frontend/fullstack only) |
+| **Set up Playwright?** | E2E testing with Playwright (frontend only) |
 
 All existing files are left untouched (the CLI skips them with a notice). The wizard supports `← Back` navigation to revisit previous choices.
 
@@ -183,7 +184,7 @@ The frontend gets its own `eslint.config.js` with:
 
 ## Playwright E2E testing
 
-Available for **frontend** and **fullstack** project types. When enabled:
+Available for **frontend** project types. When enabled:
 
 - Installs `@playwright/test`
 - Copies `playwright.config.ts` (configured with `testDir: 'tests/e2e'`, `baseURL: 'http://localhost:5173'`)
@@ -218,13 +219,13 @@ npm create @jeportie/tskickstart
         └──▶ npm downloads the create-tskickstart package
             └──▶ node runs ./src/index.js
                 │
-                ├─ 1. prompt — project type (npm-lib / cli / backend / frontend / app / fullstack)
+                ├─ 1. prompt — project type (npm-lib / cli / backend / frontend / app)
                 ├─ 2. prompt — type-specific options (framework, Docker, semantic-release, etc.)
                 ├─ 3. prompt — author name (git config → prompt)
                 ├─ 4. prompt — lint options (cspell / secretlint / commitlint)
                 ├─ 5. prompt — Vitest preset (none / native / coverage)
                 ├─ 6. prompt — pre-commit hook (husky + lint-staged)
-                ├─ 7. prompt — Playwright E2E (frontend/fullstack only)
+                ├─ 7. prompt — Playwright E2E (frontend only)
                 ├─ 8. ensure package.json + "type": "module"
                 ├─ 9. npm install all selected dependencies
                 ├─ 10. copy common config templates → project root
@@ -478,7 +479,7 @@ VITEST_PRESET=native node ./src/index.js
 VITEST_PRESET=coverage node ./src/index.js
 VITEST_PRESET=none node ./src/index.js
 
-# Playwright (frontend/fullstack only)
+# Playwright (frontend only)
 PLAYWRIGHT=1 node ./src/index.js
 PLAYWRIGHT=0 node ./src/index.js
 

--- a/src/prompts/playwright.js
+++ b/src/prompts/playwright.js
@@ -6,7 +6,7 @@ function fromEnv() {
 }
 
 export async function askPlaywrightQuestion(projectType) {
-  if (projectType !== 'frontend' && projectType !== 'fullstack') {
+  if (projectType !== 'frontend') {
     return { setupPlaywright: false };
   }
 

--- a/src/prompts/project-type.js
+++ b/src/prompts/project-type.js
@@ -20,7 +20,6 @@ export async function askProjectType() {
         { name: 'backend service', value: 'backend' },
         { name: 'frontend app', value: 'frontend' },
         { name: 'mobile app', value: 'app' },
-        { name: 'fullstack app', value: 'fullstack' },
       ],
     },
   ]);

--- a/tests/integration/database-boundary.int.test.js
+++ b/tests/integration/database-boundary.int.test.js
@@ -1,0 +1,60 @@
+import { execSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliPath = resolve(__dirname, '../../src/index.js');
+
+function createTmpProject(name = 'test-boundary') {
+  const dir = mkdtempSync(join(tmpdir(), 'tskickstart-db-boundary-'));
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name, version: '1.0.0' }, null, 2));
+  return dir;
+}
+
+function runCli(cwd, extraEnv = {}) {
+  execSync(`node ${cliPath}`, {
+    cwd,
+    env: { ...process.env, NO_INSTALL: '1', ...extraEnv },
+    stdio: 'pipe',
+  });
+}
+
+describe('database capability boundary', () => {
+  let tmpDir;
+
+  afterEach(() => {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('enables database scaffolding for backend projects', () => {
+    tmpDir = createTmpProject('test-backend-boundary');
+    runCli(tmpDir, {
+      PROJECT_TYPE: 'backend',
+      BACKEND_FRAMEWORK: 'hono',
+      SETUP_DATABASE: '1',
+      DB_ENGINE: 'postgresql',
+      DB_ORM: 'none',
+      DOCKER: '0',
+    });
+
+    expect(existsSync(join(tmpDir, 'src/db/index.ts'))).toBe(true);
+  });
+
+  it('does not scaffold database for non-backend project types', () => {
+    tmpDir = createTmpProject('test-frontend-boundary');
+    runCli(tmpDir, {
+      PROJECT_TYPE: 'frontend',
+      SETUP_DATABASE: '1',
+      DB_ENGINE: 'postgresql',
+      DB_ORM: 'none',
+    });
+
+    expect(existsSync(join(tmpDir, 'src/db'))).toBe(false);
+    const readme = readFileSync(join(tmpDir, 'README.md'), 'utf-8');
+    expect(readme).not.toContain('## Database');
+  });
+});


### PR DESCRIPTION
## Summary
- codified boundary that database scaffolding is backend-only and removed current fullstack project option from the wizard surface
- updated Playwright prompt/docs wording from frontend/fullstack to frontend-only for current product scope
- added integration test coverage proving DB scaffolding runs for backend and not for non-backend project types

## Verification
- npm run test -- tests/integration/database-boundary.int.test.js