### PR TITLE
CF-009: add optional secret capture and env bootstrap

### DIFF
--- a/src/generators/common.js
+++ b/src/generators/common.js
@@ -56,6 +56,43 @@ async function appendIgnorePathsToCspell(cwd, ignorePaths) {
   await fs.writeJson(cspellPath, cspellJson, { spaces: 2 });
 }
 
+function normalizeEnvLines(content) {
+  return content
+    .split('\n')
+    .filter(Boolean)
+    .reduce((acc, line) => {
+      const [key] = line.split('=');
+      if (!key) return acc;
+      acc[key] = line.slice(key.length + 1);
+      return acc;
+    }, {});
+}
+
+async function bootstrapEnvFiles(cwd, answers) {
+  if (!answers.captureSecrets) return;
+
+  const secretValues = answers.secretValues ?? {};
+  const envExamplePath = path.join(cwd, '.env.example');
+  const envLocalPath = path.join(cwd, '.env.local');
+
+  const envExampleContent = (await fs.pathExists(envExamplePath)) ? await fs.readFile(envExamplePath, 'utf-8') : '';
+  const envLocalContent = (await fs.pathExists(envLocalPath)) ? await fs.readFile(envLocalPath, 'utf-8') : '';
+
+  const exampleMap = normalizeEnvLines(envExampleContent);
+  const localMap = normalizeEnvLines(envLocalContent);
+
+  for (const key of Object.keys(secretValues)) {
+    if (!(key in exampleMap)) exampleMap[key] = '';
+    if (!(key in localMap)) localMap[key] = secretValues[key] ?? '';
+  }
+
+  const exampleLines = Object.entries(exampleMap).map(([key, value]) => `${key}=${value}`);
+  const localLines = Object.entries(localMap).map(([key, value]) => `${key}=${value}`);
+
+  await fs.writeFile(envExamplePath, `${exampleLines.join('\n')}\n`);
+  await fs.writeFile(envLocalPath, `${localLines.join('\n')}\n`);
+}
+
 export async function generateCommon(answers, cwd = process.cwd()) {
   const pkgPath = path.join(cwd, 'package.json');
   const { lintOption = [], vitestPreset, setupPrecommit = true, authorName, projectType, linter = 'eslint' } = answers;
@@ -274,6 +311,8 @@ describe('helloWorld', () => {
   } else {
     console.log(pc.dim('–') + '    README.md (already exists, skipped)');
   }
+
+  await bootstrapEnvFiles(cwd, answers);
 
   await generateCicd(answers, cwd);
 }

--- a/src/prompts/common.js
+++ b/src/prompts/common.js
@@ -117,6 +117,36 @@ export async function askCommonQuestions(projectType) {
     }
   }
 
+  let captureSecrets = false;
+  if (process.env.SECRET_CAPTURE === '1') {
+    captureSecrets = true;
+  } else if (process.env.SECRET_CAPTURE === '0') {
+    captureSecrets = false;
+  } else if (process.stdin.isTTY) {
+    const result = await prompt([
+      {
+        type: 'confirm',
+        name: 'captureSecrets',
+        message: 'Capture starter secrets and bootstrap .env files?',
+        default: true,
+      },
+    ]);
+    captureSecrets = result.captureSecrets;
+  }
+
+  const secretValues = {};
+  if (captureSecrets) {
+    if (process.env.SECRET_DATABASE_URL !== undefined) {
+      secretValues.DATABASE_URL = process.env.SECRET_DATABASE_URL;
+    }
+    if (process.env.SECRET_REDIS_URL !== undefined) {
+      secretValues.REDIS_URL = process.env.SECRET_REDIS_URL;
+    }
+    if (process.env.SECRET_APP_SECRET !== undefined) {
+      secretValues.APP_SECRET = process.env.SECRET_APP_SECRET;
+    }
+  }
+
   return {
     linter,
     lintOption,
@@ -125,5 +155,7 @@ export async function askCommonQuestions(projectType) {
     ...cicdAnswers,
     setupPrecommit,
     authorName,
+    captureSecrets,
+    secretValues,
   };
 }

--- a/tests/integration/secrets.int.test.js
+++ b/tests/integration/secrets.int.test.js
@@ -1,0 +1,55 @@
+import { execSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliPath = resolve(__dirname, '../../src/index.js');
+
+function createTmpProject() {
+  const dir = mkdtempSync(join(tmpdir(), 'tskickstart-secrets-'));
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'test-secrets', version: '1.0.0' }, null, 2));
+  return dir;
+}
+
+function runCli(cwd, extraEnv = {}) {
+  execSync(`node ${cliPath}`, {
+    cwd,
+    env: { ...process.env, NO_INSTALL: '1', PROJECT_TYPE: 'backend', BACKEND_FRAMEWORK: 'hono', ...extraEnv },
+    stdio: 'pipe',
+  });
+}
+
+describe('secret capture env bootstrap', () => {
+  let tmpDir;
+
+  afterEach(() => {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes .env.example and .env.local with captured secret values', () => {
+    tmpDir = createTmpProject();
+    runCli(tmpDir, {
+      SETUP_DATABASE: '1',
+      DB_ENGINE: 'postgresql',
+      DB_ORM: 'none',
+      SECRET_CAPTURE: '1',
+      SECRET_DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/app',
+      SECRET_APP_SECRET: 'local-dev-secret',
+    });
+
+    expect(existsSync(join(tmpDir, '.env.example'))).toBe(true);
+    expect(existsSync(join(tmpDir, '.env.local'))).toBe(true);
+
+    const envExample = readFileSync(join(tmpDir, '.env.example'), 'utf-8');
+    expect(envExample).toContain('DATABASE_URL=');
+    expect(envExample).toContain('APP_SECRET=');
+
+    const envLocal = readFileSync(join(tmpDir, '.env.local'), 'utf-8');
+    expect(envLocal).toContain('DATABASE_URL=postgresql://postgres:postgres@localhost:5432/app');
+    expect(envLocal).toContain('APP_SECRET=local-dev-secret');
+  });
+});


### PR DESCRIPTION
## Summary
- added optional secret-capture flow with env-driven support for non-interactive runs
- bootstraps `.env.example` and `.env.local` from captured values while keeping examples commit-safe
- added integration test coverage for captured `DATABASE_URL` and `APP_SECRET` propagation

## Verification
- npm run test -- tests/integration/secrets.int.test.js