### PR TITLE
CF-010: add optional integration presets (Better Auth starter)

### DIFF
--- a/src/generators/backend.js
+++ b/src/generators/backend.js
@@ -22,6 +22,77 @@ async function appendGitignoreEntries(cwd) {
   }
 }
 
+async function upsertEnvExampleEntries(cwd, entries) {
+  const envPath = path.join(cwd, '.env.example');
+  let content = '';
+  if (await fs.pathExists(envPath)) {
+    content = await fs.readFile(envPath, 'utf-8');
+  }
+
+  const lines = content.split('\n').filter(Boolean);
+  const map = new Map(
+    lines.map((line) => {
+      const [key, ...rest] = line.split('=');
+      return [key, rest.join('=')];
+    }),
+  );
+
+  for (const [key, value] of Object.entries(entries)) {
+    map.set(key, value);
+  }
+
+  const next = [...map.entries()].map(([key, value]) => `${key}=${value}`);
+  await fs.writeFile(envPath, `${next.join('\n')}\n`);
+}
+
+async function appendIntegrationReadme(cwd, name) {
+  const readmePath = path.join(cwd, 'README.md');
+  if (!(await fs.pathExists(readmePath))) return;
+
+  const content = await fs.readFile(readmePath, 'utf-8');
+  if (content.includes('## Integrations')) return;
+
+  const section = `
+
+## Integrations
+
+### ${name}
+
+- Starter wiring is generated in \`src/integrations/${name === 'Better Auth' ? 'better-auth' : 'integration'}.ts\`
+- Add provider credentials to \`.env.local\` and keep placeholders in \`.env.example\`
+`;
+  await fs.writeFile(readmePath, `${content}${section}`);
+}
+
+async function generateIntegrationPreset(answers, cwd) {
+  const preset = answers.integrationPreset ?? 'none';
+  if (preset !== 'better-auth') return;
+
+  const integrationsDir = path.join(cwd, 'src/integrations');
+  await fs.ensureDir(integrationsDir);
+  await fs.writeFile(
+    path.join(integrationsDir, 'better-auth.ts'),
+    `export type BetterAuthConfig = {
+  baseUrl: string;
+  secret: string;
+};
+
+export function getBetterAuthConfig(): BetterAuthConfig {
+  return {
+    baseUrl: process.env.BETTER_AUTH_URL ?? 'http://localhost:3000',
+    secret: process.env.BETTER_AUTH_SECRET ?? '',
+  };
+}
+`,
+  );
+
+  await upsertEnvExampleEntries(cwd, {
+    BETTER_AUTH_URL: 'http://localhost:3000',
+    BETTER_AUTH_SECRET: '',
+  });
+  await appendIntegrationReadme(cwd, 'Better Auth');
+}
+
 export async function generateBackend(answers, cwd) {
   const { backendFramework = 'hono', setupDocker = true, setupZod = true } = answers;
 
@@ -77,4 +148,5 @@ export async function generateBackend(answers, cwd) {
   }
 
   await generateDatabase(answers, cwd);
+  await generateIntegrationPreset(answers, cwd);
 }

--- a/src/prompts/backend.js
+++ b/src/prompts/backend.js
@@ -58,5 +58,24 @@ export async function askBackendQuestions() {
 
   const databaseAnswers = await askDatabaseQuestions();
 
-  return { backendFramework, setupZod, setupDocker, ...databaseAnswers };
+  let integrationPreset = 'none';
+  if (process.env.INTEGRATION_PRESET) {
+    integrationPreset = process.env.INTEGRATION_PRESET;
+  } else if (process.stdin.isTTY) {
+    const result = await prompt([
+      {
+        type: 'list',
+        name: 'integrationPreset',
+        message: 'Optional integration preset?',
+        choices: [
+          { name: 'None', value: 'none' },
+          { name: 'Better Auth starter', value: 'better-auth' },
+        ],
+        default: 'none',
+      },
+    ]);
+    integrationPreset = result.integrationPreset;
+  }
+
+  return { backendFramework, setupZod, setupDocker, integrationPreset, ...databaseAnswers };
 }

--- a/tests/integration/backend.int.test.js
+++ b/tests/integration/backend.int.test.js
@@ -321,4 +321,22 @@ describe('backend project scaffold', () => {
     const content = readFileSync(join(tmpDir, 'README.md'), 'utf-8');
     expect(content).toContain('Docker');
   });
+
+  it('scaffolds Better Auth integration preset when selected', () => {
+    tmpDir = createTmpProject();
+    runCli(tmpDir, {
+      BACKEND_FRAMEWORK: 'hono',
+      DOCKER: '0',
+      INTEGRATION_PRESET: 'better-auth',
+    });
+
+    expect(existsSync(join(tmpDir, 'src/integrations/better-auth.ts'))).toBe(true);
+
+    const envExample = readFileSync(join(tmpDir, '.env.example'), 'utf-8');
+    expect(envExample).toContain('BETTER_AUTH_SECRET=');
+
+    const readme = readFileSync(join(tmpDir, 'README.md'), 'utf-8');
+    expect(readme).toContain('## Integrations');
+    expect(readme).toContain('Better Auth');
+  });
 });


### PR DESCRIPTION
## Summary
- added backend wizard integration preset selection with an initial `better-auth` starter option
- scaffold now generates `src/integrations/better-auth.ts`, appends required env placeholders, and documents the integration in README
- added integration coverage for preset prompt/env wiring and generated starter files

## Verification
- npm run test -- tests/integration/backend.int.test.js