### PR TITLE
fix: add explicit ignore patterns to generated biome.json

### DIFF
--- a/src/templates/common/biome.json
+++ b/src/templates/common/biome.json
@@ -1,5 +1,8 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+  "files": {
+    "ignore": ["dist", "node_modules", "package-lock.json", "coverage"]
+  },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",

--- a/tests/integration/biome.int.test.js
+++ b/tests/integration/biome.int.test.js
@@ -58,6 +58,17 @@ describe('biome option', () => {
     expect(content).toContain('useNodejsImportProtocol');
   });
 
+  it('adds explicit ignore patterns to biome config', () => {
+    tmpDir = createTmpProject();
+    runCli(tmpDir, { LINTER: 'biome' });
+
+    const biomeConfig = JSON.parse(readFileSync(join(tmpDir, 'biome.json'), 'utf-8'));
+    expect(biomeConfig.files).toBeDefined();
+    expect(biomeConfig.files.ignore).toEqual(
+      expect.arrayContaining(['dist', 'node_modules', 'package-lock.json', 'coverage']),
+    );
+  });
+
   it('keeps cspell standalone when biome is selected', () => {
     tmpDir = createTmpProject();
     runCli(tmpDir, { LINTER: 'biome', LINT_OPTIONS: 'cspell' });


### PR DESCRIPTION
## Summary
- add generated Biome ignore entries for dist, node_modules, package-lock.json, and coverage
- assert the ignore list in the Biome integration test

Closes #41