### PR TITLE
docs: adapt generated README commands to chosen package manager

### DIFF
--- a/src/utils/readme.js
+++ b/src/utils/readme.js
@@ -207,6 +207,22 @@ function getQualityStackLabel(answers) {
   return tools.join(', ');
 }
 
+function getPackageManager(answers) {
+  if (answers.projectType !== 'npm-lib') return 'npm';
+  return answers.packageManager === 'pnpm' ? 'pnpm' : 'npm';
+}
+
+function adaptPackageManagerCommands(content, answers) {
+  if (getPackageManager(answers) !== 'pnpm') return content;
+
+  return content
+    .replaceAll('npm install', 'pnpm install')
+    .replaceAll('npm test', 'pnpm test')
+    .replaceAll('npm start', 'pnpm start')
+    .replaceAll('npm publish', 'pnpm publish')
+    .replaceAll('npm run ', 'pnpm ');
+}
+
 function joinHumanList(items) {
   if (items.length === 0) return '';
   if (items.length === 1) return items[0];
@@ -4286,7 +4302,7 @@ export function generateReadme(answers) {
 
   sections.push(`## Scripts Reference\n\n${getScriptsTable(answers)}`);
 
-  return sections.join('\n\n---\n\n') + '\n';
+  return adaptPackageManagerCommands(sections.join('\n\n---\n\n'), answers) + '\n';
 }
 
 export async function writeReadme(answers, cwd) {

--- a/tests/integration/npm-lib.int.test.js
+++ b/tests/integration/npm-lib.int.test.js
@@ -141,4 +141,16 @@ describe('npm-lib project scaffold', () => {
     expect(content).toContain('tsup');
     expect(content).toContain('semantic-release');
   });
+
+  it('uses pnpm commands in README when PKG_MANAGER=pnpm', () => {
+    tmpDir = createTmpProject();
+    runCli(tmpDir, { SEMANTIC_RELEASE: '1', PKG_MANAGER: 'pnpm' });
+
+    const content = readFileSync(join(tmpDir, 'README.md'), 'utf-8');
+    expect(content).toContain('pnpm install');
+    expect(content).toContain('pnpm build');
+    expect(content).toContain('pnpm check');
+    expect(content).not.toContain('npm run build');
+    expect(content).not.toContain('npm run check');
+  });
 });

--- a/tests/integration/readme.int.test.js
+++ b/tests/integration/readme.int.test.js
@@ -56,6 +56,7 @@ function npmLibAnswers(overrides = {}) {
   return {
     _pkgName: 'demo-lib',
     projectType: 'npm-lib',
+    packageManager: 'npm',
     lintOption: ['cspell', 'commitlint'],
     vitestPreset: 'coverage',
     setupSemanticRelease: true,
@@ -415,6 +416,16 @@ describe('README generation detail (preserved)', () => {
     expect(content).toContain('Granular Access Token');
     expect(content).toContain('NPM_TOKEN');
     expect(content).toContain('GITHUB_TOKEN');
+  });
+
+  it('uses pnpm commands in npm-lib README when pnpm is selected', () => {
+    const content = generateReadme(npmLibAnswers({ packageManager: 'pnpm' }));
+
+    expect(content).toContain('pnpm install');
+    expect(content).toContain('pnpm build');
+    expect(content).toContain('pnpm check');
+    expect(content).not.toContain('npm run build');
+    expect(content).not.toContain('npm run check');
   });
 
   it('includes backend-specific framework and infra guidance', () => {


### PR DESCRIPTION
## Summary
- switch npm-lib README commands to pnpm when the generated project selected pnpm
- cover both direct README generation and scaffolded README output in tests

Closes #44