### PR TITLE
fix: resolve Biome lint errors in generated frontend templates

### DIFF
--- a/src/templates/frontend/src/Welcome.tsx
+++ b/src/templates/frontend/src/Welcome.tsx
@@ -46,6 +46,7 @@ export default function Welcome() {
       <h1 className="animate-bounce text-4xl font-bold leading-tight my-4">Vite + React + Tailwind</h1>
       <div className="p-8 border-black border-solid border-2 rounded-lg flex flex-col items-center">
         <button
+          type="button"
           onClick={() => setCount((prev) => prev + 1)}
           className="
             text-white rounded-lg border border-amber-600

--- a/src/templates/frontend/src/main.tsx
+++ b/src/templates/frontend/src/main.tsx
@@ -15,4 +15,8 @@ export function AppSetup() {
   );
 }
 
-createRoot(document.getElementById('root')!).render(<AppSetup />);
+const root = document.getElementById('root');
+
+if (!root) throw new Error('Root element not found');
+
+createRoot(root).render(<AppSetup />);

--- a/tests/integration/frontend.int.test.js
+++ b/tests/integration/frontend.int.test.js
@@ -59,6 +59,19 @@ describe('frontend starter scaffold', () => {
     expect(existsSync(join(tmpDir, 'src', 'assets', 'vite.svg'))).toBe(true);
   });
 
+  it('uses a root null guard and explicit button type in starter templates', () => {
+    tmpDir = createTmpProject();
+    runCli(tmpDir);
+
+    const mainContent = readFileSync(join(tmpDir, 'src', 'main.tsx'), 'utf-8');
+    expect(mainContent).toContain("const root = document.getElementById('root');");
+    expect(mainContent).toContain("if (!root) throw new Error('Root element not found');");
+    expect(mainContent).not.toContain("getElementById('root')!");
+
+    const welcomeContent = readFileSync(join(tmpDir, 'src', 'Welcome.tsx'), 'utf-8');
+    expect(welcomeContent).toContain('type="button"');
+  });
+
   it('creates frontend test files', () => {
     tmpDir = createTmpProject();
     runCli(tmpDir);


### PR DESCRIPTION
## Summary
- replace the frontend root non-null assertion with a runtime guard
- add an explicit button type and cover both template fixes in integration tests

Closes #40