### PR TITLE
docs: add CF-037 banner regression to CURRFIX

### DIFF
--- a/CURRFIX.md
+++ b/CURRFIX.md
@@ -49,6 +49,7 @@ All reported issues are now `DONE` and merged into `dev`.
 - [x] CF-034 | PROMPTS/SECRETS | Skip "Capture secrets?" prompt for project types that don't generate env vars (frontend, npm-lib) | STATUS=DONE | reported_by=user | GH=#42 | PR=#45 merged to dev
 - [x] CF-035 | DOCS/RELEASE | Add NPM token and GitHub secret setup instructions in generated README for semantic-release projects | STATUS=DONE | reported_by=user | GH=#43 | PR=#47 merged to dev
 - [x] CF-036 | DOCS/PACKAGE-MANAGER | Adapt generated README commands to match chosen package manager (pnpm vs npm) | STATUS=DONE | reported_by=user | GH=#44 | PR=#49 merged to dev
+- [ ] CF-037 | DX/CLI | Restore full branded `tskickstart` banner; keep 80-column rule for regular CLI output only | STATUS=OPEN | reported_by=user | GH=#52
 
 ## Issue Entry Template
 


### PR DESCRIPTION
## Summary
- add CF-037 to CURRFIX.md as an open regression caused by the CF-030 width change
- link the new GitHub issue for the banner/title follow-up

Refs #52