### PR TITLE
docs: mark CF-037 done in CURRFIX

### DIFF
--- a/CURRFIX.md
+++ b/CURRFIX.md
@@ -49,7 +49,7 @@ All reported issues are now `DONE` and merged into `dev`.
 - [x] CF-034 | PROMPTS/SECRETS | Skip "Capture secrets?" prompt for project types that don't generate env vars (frontend, npm-lib) | STATUS=DONE | reported_by=user | GH=#42 | PR=#45 merged to dev
 - [x] CF-035 | DOCS/RELEASE | Add NPM token and GitHub secret setup instructions in generated README for semantic-release projects | STATUS=DONE | reported_by=user | GH=#43 | PR=#47 merged to dev
 - [x] CF-036 | DOCS/PACKAGE-MANAGER | Adapt generated README commands to match chosen package manager (pnpm vs npm) | STATUS=DONE | reported_by=user | GH=#44 | PR=#49 merged to dev
-- [ ] CF-037 | DX/CLI | Restore full branded `tskickstart` banner; keep 80-column rule for regular CLI output only | STATUS=OPEN | reported_by=user | GH=#52
+- [x] CF-037 | DX/CLI | Restore full branded `tskickstart` banner; keep 80-column rule for regular CLI output only | STATUS=DONE | reported_by=user | GH=#52 | PR=#54 merged to dev
 
 ## Issue Entry Template
 


### PR DESCRIPTION
## Summary
- mark CF-037 as done in CURRFIX.md
- record the merged GitHub issue and PR references for the banner regression fix