### PR TITLE
fix: use Biome v2-compatible file exclusions

### DIFF
--- a/src/templates/common/biome.json
+++ b/src/templates/common/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "files": {
-    "ignore": ["dist", "node_modules", "package-lock.json", "coverage"]
+    "includes": ["**", "!!**/dist", "!!**/coverage", "!package-lock.json"]
   },
   "formatter": {
     "enabled": true,

--- a/tests/integration/biome.int.test.js
+++ b/tests/integration/biome.int.test.js
@@ -58,15 +58,16 @@ describe('biome option', () => {
     expect(content).toContain('useNodejsImportProtocol');
   });
 
-  it('adds explicit ignore patterns to biome config', () => {
+  it('uses Biome v2-compatible file exclusion patterns', () => {
     tmpDir = createTmpProject();
     runCli(tmpDir, { LINTER: 'biome' });
 
     const biomeConfig = JSON.parse(readFileSync(join(tmpDir, 'biome.json'), 'utf-8'));
     expect(biomeConfig.files).toBeDefined();
-    expect(biomeConfig.files.ignore).toEqual(
-      expect.arrayContaining(['dist', 'node_modules', 'package-lock.json', 'coverage']),
+    expect(biomeConfig.files.includes).toEqual(
+      expect.arrayContaining(['**', '!!**/dist', '!!**/coverage', '!package-lock.json']),
     );
+    expect(biomeConfig.files.ignore).toBeUndefined();
   });
 
   it('keeps cspell standalone when biome is selected', () => {


### PR DESCRIPTION
## Summary
- replace the invalid `files.ignore` template with Biome v2-compatible `files.includes` exclusion patterns
- update the integration test and verify a generated project can run `biome format --write .`

Closes #56