### PR TITLE
fix: ignore pnpm lock files in generated cspell config

### DIFF
--- a/src/generators/common.js
+++ b/src/generators/common.js
@@ -136,7 +136,11 @@ export async function generateCommon(answers, cwd = process.cwd()) {
 
   if (lintOption.includes('cspell')) {
     await copyIfMissing(templatePath('common', 'cspell.json'), path.join(cwd, 'cspell.json'), 'cspell.json');
-    await appendIgnorePathsToCspell(cwd, ['dist/**']);
+    const cspellIgnorePaths = ['dist/**'];
+    if (projectType === 'npm-lib' && answers.packageManager === 'pnpm') {
+      cspellIgnorePaths.push('pnpm-lock.yaml');
+    }
+    await appendIgnorePathsToCspell(cwd, cspellIgnorePaths);
     await appendWordsToCspell(cwd, ['tskickstart', 'composable', 'preconfigured', 'precommit', 'subroutes']);
     if (authorName) {
       await appendWordsToCspell(cwd, authorName.split(/\s+/).filter(Boolean));

--- a/tests/integration/cspell.int.test.js
+++ b/tests/integration/cspell.int.test.js
@@ -162,6 +162,27 @@ describe('cspell generation', () => {
     expect(cspell.words).toContain('Tailwind');
   });
 
+  it('ignores pnpm-lock.yaml for npm-lib projects using pnpm', async () => {
+    tmpDir = createTmpProject('pnpm-lib-test-project');
+    process.env.NO_INSTALL = '1';
+
+    await generateCommon(
+      {
+        projectType: 'npm-lib',
+        packageManager: 'pnpm',
+        setupSemanticRelease: false,
+        lintOption: ['cspell'],
+        setupPrecommit: false,
+        authorName: 'Test Author',
+      },
+      tmpDir,
+    );
+
+    const cspell = JSON.parse(readFileSync(join(tmpDir, 'cspell.json'), 'utf-8'));
+    expect(cspell.ignorePaths).toContain('pnpm-lock.yaml');
+    expect(cspell.ignorePaths).toContain('package-lock.json');
+  });
+
   it('adds dist ignore path to existing cspell config', async () => {
     tmpDir = createTmpProject('existing-cspell-project');
     process.env.NO_INSTALL = '1';


### PR DESCRIPTION
## Summary
- add `pnpm-lock.yaml` to generated cspell ignore paths when npm-lib projects select pnpm
- cover the pnpm lockfile case in cspell integration tests while preserving existing ignore-path behavior

Closes #58